### PR TITLE
Initial handling of handshake

### DIFF
--- a/include/maidsafe/crux/acceptor.hpp
+++ b/include/maidsafe/crux/acceptor.hpp
@@ -100,6 +100,7 @@ acceptor::async_accept(socket_type& socket,
         {
         case socket_type::connectivity::closed:
             socket.state(socket_type::connectivity::listening);
+            socket.set_multiplexer(multiplexer);
             multiplexer->async_accept
                 (socket,
                  [this, &socket, handler]
@@ -131,20 +132,15 @@ void acceptor::process_accept(const boost::system::error_code& error,
     switch (error.value())
     {
     case 0:
-        {
-            // FIXME: set local_endpoint?
-            socket.set_multiplexer(multiplexer);
-            multiplexer->add(&socket);
-            boost::system::error_code success;
-            handler(success);
-        }
+        // FIXME: set local_endpoint?
+        multiplexer->add(&socket);
         break;
 
     case boost::asio::error::operation_aborted:
     default:
-        handler(error);
         break;
     }
+    handler(error);
 }
 
 acceptor::endpoint_type acceptor::local_endpoint() const

--- a/include/maidsafe/crux/detail/header.hpp
+++ b/include/maidsafe/crux/detail/header.hpp
@@ -33,10 +33,13 @@ const std::size_t size =
     + sizeof(std::uint32_t) // sequence number
     + sizeof(std::uint32_t); // ack sequence number
 
-const std::uint16_t type_mask = 0XF800;
+const std::uint16_t mask_type = 0XF800;
+const std::uint16_t mask_ack = 0x0004;
+
 const std::uint16_t type_data = 0xC000;
 const std::uint16_t type_handshake = 0xC800;
 const std::uint16_t type_shutdown = 0xD000;
+const std::uint16_t type_keepalive = 0xD800;
 
 } // namespace header
 } // namespace constant

--- a/include/maidsafe/crux/detail/socket_base.hpp
+++ b/include/maidsafe/crux/detail/socket_base.hpp
@@ -58,6 +58,12 @@ protected:
 
     virtual std::vector<boost::asio::mutable_buffer>* get_recv_buffers() = 0;
 
+    virtual void process_handshake(sequence_number_type initial,
+                                   endpoint_type remote_endpoint) = 0;
+
+    virtual void process_acknowledgement(sequence_number_type ack,
+                                         std::uint16_t ackfield) = 0;
+
     virtual void process_data(const boost::system::error_code&,
                               std::size_t bytes_transferred,
                               std::shared_ptr<detail::buffer>) = 0;


### PR DESCRIPTION
This patch enables acceptor-style handshaking. All header encoding/decoding is done by the multiplexer, and the "business logic" is handled by the socket.

Limitations:
- The various examples works, but the socket_suite tests hangs.
- Packet loss is not handled.
- Data packets are not acknowledged.
- Existing acknowledgement is a hack to get handshake working.
