### PR TITLE
Change remote_endpoint to loopback if unspecified

### DIFF
--- a/include/maidsafe/crux/socket.hpp
+++ b/include/maidsafe/crux/socket.hpp
@@ -60,8 +60,7 @@ public:
         typename boost::asio::handler_type<CompletionToken,
                                            void(boost::system::error_code)>::type
         >::type
-    async_connect(const endpoint_type& remote_endpoint,
-                  CompletionToken&& token);
+    async_connect(endpoint_type remote_endpoint, CompletionToken&& token);
 
     template <typename CompletionToken>
     typename boost::asio::async_result<
@@ -223,8 +222,7 @@ typename boost::asio::async_result<
     typename boost::asio::handler_type<CompletionToken,
                                        void(boost::system::error_code)>::type
     >::type
-socket::async_connect(const endpoint_type& remote_endpoint,
-                      CompletionToken&& token)
+socket::async_connect(endpoint_type remote_endpoint, CompletionToken&& token)
 {
     using handler_type = typename boost::asio::handler_type<CompletionToken,
                                                             void(boost::system::error_code)>::type;
@@ -243,6 +241,17 @@ socket::async_connect(const endpoint_type& remote_endpoint,
         {
         case connectivity::closed:
             state(connectivity::connecting);
+
+            if (remote_endpoint.address().is_unspecified()) {
+                if (remote_endpoint.address().is_v4()) {
+                    remote_endpoint.address(boost::asio::ip::address_v4::loopback());
+                }
+                else {
+                    assert(remote_endpoint.address().is_v6());
+                    remote_endpoint.address(boost::asio::ip::address_v6::loopback());
+                }
+            }
+
             remote = remote_endpoint;
             multiplexer->add(this);
             multiplexer->send_handshake
@@ -543,7 +552,7 @@ void socket::process_handshake(sequence_number_type initial,
         assert(multiplexer);
         multiplexer->send_handshake
             (remote_endpoint,
-             sequence_number_type(next_sequence++),
+             next_sequence++,
              initial,
              0, // FIXME
              [this, remote_endpoint]

--- a/test/socket.cpp
+++ b/test/socket.cpp
@@ -106,8 +106,7 @@ BOOST_AUTO_TEST_CASE(double_send_and_receive)
                   BOOST_ASSERT(!error);
                   BOOST_ASSERT(size == message1_text.size());
                   BOOST_REQUIRE_EQUAL
-                      ( std::string(rx_data.begin(), rx_data.end())
-                      , message1_text);
+                      (to_string(rx_data), message1_text);
 
                   rx_data.assign(blank_message.begin(), blank_message.end());
 
@@ -117,8 +116,7 @@ BOOST_AUTO_TEST_CASE(double_send_and_receive)
                           BOOST_ASSERT(!error);
                           BOOST_REQUIRE_EQUAL(size, rx_data.size());
                           BOOST_REQUIRE_EQUAL
-                            ( std::string(rx_data.begin(), rx_data.end())
-                            , message2_text);
+                            (to_string(rx_data), message2_text);
                       });
                 });
             });
@@ -176,8 +174,7 @@ BOOST_AUTO_TEST_CASE(single_exchange)
                   BOOST_ASSERT(!error);
                   BOOST_ASSERT(size == message1_text.size());
                   BOOST_REQUIRE_EQUAL
-                      ( std::string(server_rx_data.begin(), server_rx_data.end())
-                      , message1_text);
+                      (to_string(server_rx_data), message1_text);
 
                   server_socket.async_send(
                       asio::buffer(server_tx_data),
@@ -207,9 +204,7 @@ BOOST_AUTO_TEST_CASE(single_exchange)
                             BOOST_REQUIRE_EQUAL(size, message2_text.size());
 
                             BOOST_REQUIRE_EQUAL
-                                ( std::string( server_rx_data.begin()
-                                             , server_rx_data.end())
-                                , message2_text);
+                                (to_string(client_rx_data), message2_text);
                       });
                });
            });


### PR DESCRIPTION
If we send a packet to unspecified endpoint it is sent
to loopback, but we never receive from an unspecified
address (0.0.0.0) so we musn't store the socket
by that key or otherwise multiplexer wouldn't match
incomming packets with our socket.