### PR TITLE
Port over the fixes so far made to FreeBSD port.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ endif()
 
 # FreeBSD needs you to link pthread (symlinks to the libthr 1:1 threading implementation) explicitly
 if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  # Temporarily disable kqueues on FreeBSD as we have enough problems with just the select() based reactor
+  add_definitions(-DBOOST_ASIO_DISABLE_KQUEUE=1)
   set(EXTRA_LIBS ${EXTRA_LIBS} pthread)
   set(TEST_LIBS ${TEST_LIBS} pthread)
 endif()

--- a/include/maidsafe/crux/detail/multiplexer.hpp
+++ b/include/maidsafe/crux/detail/multiplexer.hpp
@@ -439,6 +439,11 @@ void multiplexer::process_peek(boost::system::error_code error,
     next_layer_type::bytes_readable command(true);
     next_layer().io_control(command);
     std::size_t datagram_size = command.get();
+#ifdef __FreeBSD__
+    // FreeBSD's FIONREAD when asked of a UDP socket includes the UDP and IP headers which
+    // for IPv4 is 16 bytes and for IPv6 is 24 bytes
+    datagram_size -= remote_endpoint.address().is_v6() ? 24 : 16;
+#endif
 
     if (datagram_size < header_size) {
         // Our empty packet, corrupted packet or someone is being silly.


### PR DESCRIPTION
The fixes below nearly get a functional CRUX port to FreeBSD - albeit with the enormous hack of disabling kqueues. The single remaining problem is that crux::acceptor::async_accept is never calling its handler, and therefore later on when the keepalive timeout occurs we see its handler being called with ECANCELED due to the client socket being closed which trips several asserts, and aborts the application. I assume I'll tease out the cause of async_accept not calling its handler tomorrow, and when I do I'll push the fix to this pull request. Meanwhile feel free to merge the below as is if acceptable.