### PR TITLE
Maid 928

### DIFF
--- a/include/maidsafe/crux/acceptor.hpp
+++ b/include/maidsafe/crux/acceptor.hpp
@@ -87,7 +87,8 @@ inline acceptor::~acceptor()
 
 inline void acceptor::close() {
     if (!multiplexer) return;
-    multiplexer->disable_accept_requests_from(*this);
+    auto m = std::move(multiplexer);
+    m->disable_accept_requests_from(*this);
 }
 
 template <typename CompletionToken>

--- a/include/maidsafe/crux/detail/multiplexer.hpp
+++ b/include/maidsafe/crux/detail/multiplexer.hpp
@@ -202,10 +202,6 @@ inline void multiplexer::remove(socket_base *socket)
     assert(socket);
 
     sockets.erase(socket->remote_endpoint());
-
-    if (sockets.empty()) {
-        next_layer().close();
-    }
 }
 
 template <typename AcceptorType,

--- a/include/maidsafe/crux/detail/multiplexer.hpp
+++ b/include/maidsafe/crux/detail/multiplexer.hpp
@@ -392,7 +392,7 @@ void multiplexer::process_peek(boost::system::error_code error,
 {
     namespace asio = boost::asio;
 
-    is_receiving.store(false);
+    is_receiving = false;
 
     if (!next_layer().is_open()) return;
 

--- a/include/maidsafe/crux/detail/multiplexer.hpp
+++ b/include/maidsafe/crux/detail/multiplexer.hpp
@@ -462,7 +462,11 @@ void multiplexer::process_peek(boost::system::error_code error,
         if (recv_buffers) {
             next_layer().receive_from
                 ( concatenate( asio::buffer(header_data)
-                               , std::move(*recv_buffers))
+                               // Temporary workaround: we can't move these buffers
+                               // because what we receive might not be a data packet.
+                               // TODO: Get the header data in the message peek call.
+                               //, std::move(*recv_buffers))
+                               , *recv_buffers)
                   , remote_endpoint
                   , next_layer_type::message_flags()
                   , error );

--- a/include/maidsafe/crux/detail/multiplexer.hpp
+++ b/include/maidsafe/crux/detail/multiplexer.hpp
@@ -443,6 +443,11 @@ void multiplexer::process_peek(boost::system::error_code error,
     header::data_type header_data;
     std::size_t payload_size = datagram_size - header_size;
 
+    // Temporarily increase the count by one to prevent callbacks
+    // from decreasing it to zero and thus sending ourself an empty packet.
+    // It shall be decreased back by one at the end of this function.
+    ++receive_calls;
+
     // FIXME: gather-read (header, body)
     // FIXME: Make socket.receive_from commands async.
     if (recipient == sockets.end())
@@ -501,7 +506,7 @@ void multiplexer::process_peek(boost::system::error_code error,
         }
     }
 
-    if (receive_calls > 0) {
+    if (--receive_calls > 0) {
         do_start_receive();
     }
 }

--- a/include/maidsafe/crux/detail/socket_base.hpp
+++ b/include/maidsafe/crux/detail/socket_base.hpp
@@ -73,7 +73,6 @@ protected:
                               sequence_type) = 0;
 
     virtual void process_keepalive(sequence_type) = 0;
-    virtual void idempotent_start_receive() = 0;
 
     virtual void close() = 0;
 

--- a/include/maidsafe/crux/socket.hpp
+++ b/include/maidsafe/crux/socket.hpp
@@ -254,16 +254,16 @@ inline void socket::close() {
     keepalive_timer.stop();
     transmit_queue.shutdown();
 
-    auto m = multiplexer;
+    auto pin = multiplexer;
 
     while (!receive_input_queue.empty()) {
         auto handler = std::move(receive_input_queue.front()->handler);
         receive_input_queue.pop();
 
 
-        get_io_service().post([handler, m]() {
+        get_io_service().post([handler, pin]() {
                 handler(boost::asio::error::operation_aborted, 0);
-                m->stop_receive();
+                pin->stop_receive();
                 });
     }
 
@@ -695,15 +695,15 @@ void socket::send_handshake(endpoint_type remote_endpoint,
     };
 
     start_receive();
-    auto m = multiplexer;
+    auto pin = multiplexer;
 
     transmit_queue.push( sequence.value()
                        , 0
                        , send_step
-                       , [handler, m]
+                       , [handler, pin]
                          (boost::system::error_code error, std::size_t) mutable {
                            handler(error);
-                           m->stop_receive();
+                           pin->stop_receive();
                          });
 }
 
@@ -748,15 +748,15 @@ void socket::send_data(endpoint_type remote_endpoint,
     };
 
     start_receive();
-    auto m = multiplexer;
+    auto pin = multiplexer;
 
     transmit_queue.push( sequence.value()
                        , boost::asio::buffer_size(buffers)
                        , send_step
-                       , [handler, m]( boost::system::error_code error
-                                     , std::size_t size) mutable {
+                       , [handler, pin]( boost::system::error_code error
+                                       , std::size_t size) mutable {
                          handler(error, size);
-                         m->stop_receive();
+                         pin->stop_receive();
                        });
 }
 

--- a/include/maidsafe/crux/socket.hpp
+++ b/include/maidsafe/crux/socket.hpp
@@ -119,7 +119,9 @@ private:
 
     virtual void process_handshake(sequence_type initial,
                                    endpoint_type remote_endpoint) override;
+
     virtual void process_acknowledgement(const ack_sequence_type& ack) override;
+
     virtual void process_data(const boost::system::error_code& error,
                               std::size_t payload_size,
                               std::shared_ptr<detail::buffer> payload,
@@ -181,8 +183,7 @@ private:
     bool is_expected_packet(sequence_type seq);
 
     void on_any_packet_received();
-    void idempotent_start_receive() override;
-    void idempotent_stop_receive();
+    void start_receive();
     void on_keepalive_timeout();
 
 private:
@@ -253,34 +254,32 @@ inline void socket::close() {
     keepalive_timer.stop();
     transmit_queue.shutdown();
 
+    auto m = multiplexer;
+
     while (!receive_input_queue.empty()) {
         auto handler = std::move(receive_input_queue.front()->handler);
         receive_input_queue.pop();
 
-        get_io_service().post([handler]() {
+
+        get_io_service().post([handler, m]() {
                 handler(boost::asio::error::operation_aborted, 0);
+                m->stop_receive();
                 });
     }
 
     get_service().remove(local_endpoint());
-    idempotent_stop_receive();
     multiplexer->remove(this);
     multiplexer = 0;
 }
 
-inline void socket::idempotent_stop_receive() {
-    if (!is_receiving) { return; }
-    is_receiving = false;
-    multiplexer->stop_receive();
-}
+inline void socket::start_receive() {
+    if (!is_receiving) {
+      is_receiving = true;
+      keepalive_timer.set_period(detail::constant::keepalive_timeout);
+      keepalive_timer.start();
+    }
 
-inline void socket::idempotent_start_receive() {
-    if (is_receiving) { return; }
-    is_receiving = true;
     multiplexer->start_receive();
-
-    keepalive_timer.set_period(detail::constant::keepalive_timeout);
-    keepalive_timer.start();
 }
 
 inline void socket::on_any_packet_received() {
@@ -534,7 +533,7 @@ socket::async_receive(const MutableBufferSequence& buffers,
 
             receive_input_queue.emplace(std::move(operation));
 
-            idempotent_start_receive();
+            start_receive();
         }
         else
         {
@@ -624,8 +623,6 @@ void socket::process_data(const boost::system::error_code& error,
     on_any_packet_received();
 
     if (!is_expected_packet(sequence_number)) {
-        // We were receiving, so we need to continue to do so.
-        idempotent_start_receive();
         return;
     }
 
@@ -657,10 +654,8 @@ void socket::process_data(const boost::system::error_code& error,
                        [] (boost::system::error_code) {});
 
         process_receive(error, payload_size, std::move(input->handler));
-    }
 
-    if (!receive_input_queue.empty() || !transmit_queue.empty()) {
-        idempotent_start_receive();
+        multiplexer->stop_receive();
     }
 }
 
@@ -669,7 +664,6 @@ void socket::process_keepalive(sequence_type sequence_number) {
     on_any_packet_received();
 
     if (!is_expected_packet(sequence_number)) {
-        idempotent_start_receive();
         return;
     }
 
@@ -700,14 +694,16 @@ void socket::send_handshake(endpoint_type remote_endpoint,
              });
     };
 
-    idempotent_start_receive();
+    start_receive();
+    auto m = multiplexer;
 
     transmit_queue.push( sequence.value()
                        , 0
                        , send_step
-                       , [handler]
+                       , [handler, m]
                          (boost::system::error_code error, std::size_t) mutable {
                            handler(error);
+                           m->stop_receive();
                          });
 }
 
@@ -751,12 +747,17 @@ void socket::send_data(endpoint_type remote_endpoint,
              });
     };
 
-    idempotent_start_receive();
+    start_receive();
+    auto m = multiplexer;
 
     transmit_queue.push( sequence.value()
                        , boost::asio::buffer_size(buffers)
                        , send_step
-                       , handler);
+                       , [handler, m]( boost::system::error_code error
+                                     , std::size_t size) mutable {
+                         handler(error, size);
+                         m->stop_receive();
+                       });
 }
 
 inline
@@ -855,11 +856,6 @@ void socket::process_acknowledgement(const ack_sequence_type& ack)
     }
 
     transmit_queue.apply_ack(ack.value());
-
-    if (!transmit_queue.empty()) {
-        idempotent_start_receive();
-    }
-
 }
 
 template <typename Handler,

--- a/include/maidsafe/crux/socket.hpp
+++ b/include/maidsafe/crux/socket.hpp
@@ -766,6 +766,10 @@ void socket::process_handshake(sequence_type initial,
 {
     on_any_packet_received();
 
+    if (!is_expected_packet(initial)) {
+        return;
+    }
+
     sequence_history.insert(initial);
 
     switch (state())


### PR DESCRIPTION
https://maidsafe.atlassian.net/browse/MAID-928
- thread safe crux::detail::service
- implicit close of the multiplexer
- ditch the socket::idempotent_start_receive approach to recv action bookkeeping
- few other fixes
